### PR TITLE
fix/Registration_Login_Controllers

### DIFF
--- a/StudyBox_iOS.xcodeproj/project.pbxproj
+++ b/StudyBox_iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		2DBB4D3B1C88E020004F4725 /* DataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB4D3A1C88E020004F4725 /* DataManagerTests.swift */; };
 		2DBC00181C89AAF5006B4DC0 /* Array+FindUnique.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBC00171C89AAF5006B4DC0 /* Array+FindUnique.swift */; };
 		2DD02DAB1C8CCE2B00A6FED9 /* UserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD02DAA1C8CCE2B00A6FED9 /* UserViewController.swift */; };
+		2DE184081CB252C400E77F2F /* Reachability+isConnected.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE184071CB252C400E77F2F /* Reachability+isConnected.swift */; };
+		2DE1840A1CB2739600E77F2F /* UITextField+isEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE184091CB2739600E77F2F /* UITextField+isEmpty.swift */; };
+		2DE1840E1CB27DD700E77F2F /* EmailValidatableTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DE1840D1CB27DD600E77F2F /* EmailValidatableTextField.swift */; };
 		2DFB7B231C88F7EE00164464 /* DataManager+DummyData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DFB7B221C88F7EE00164464 /* DataManager+DummyData.swift */; };
 		33E3825F287BBE538984A59F /* Pods_StudyBox_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 874E052467FABF5BEC1FDDDC /* Pods_StudyBox_iOS.framework */; };
 		7206C0EE1C94586B0030FA0F /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7206C0ED1C94586B0030FA0F /* SystemConfiguration.framework */; };
@@ -79,6 +82,9 @@
 		2DBB4D3A1C88E020004F4725 /* DataManagerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataManagerTests.swift; sourceTree = "<group>"; };
 		2DBC00171C89AAF5006B4DC0 /* Array+FindUnique.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+FindUnique.swift"; sourceTree = "<group>"; };
 		2DD02DAA1C8CCE2B00A6FED9 /* UserViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserViewController.swift; sourceTree = "<group>"; };
+		2DE184071CB252C400E77F2F /* Reachability+isConnected.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Reachability+isConnected.swift"; sourceTree = "<group>"; };
+		2DE184091CB2739600E77F2F /* UITextField+isEmpty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+isEmpty.swift"; sourceTree = "<group>"; };
+		2DE1840D1CB27DD600E77F2F /* EmailValidatableTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmailValidatableTextField.swift; sourceTree = "<group>"; };
 		2DFB7B221C88F7EE00164464 /* DataManager+DummyData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DataManager+DummyData.swift"; sourceTree = "<group>"; };
 		7206C0ED1C94586B0030FA0F /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		723849391C8882DE009605EE /* StudyBoxViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StudyBoxViewController.swift; sourceTree = "<group>"; };
@@ -218,6 +224,9 @@
 				2D0F98281CAB28B2003D1857 /* ValidatableTextField.swift */,
 				2D40788E1CA19E4300A782A9 /* UIApplication+appDelegate.swift */,
 				2D0939A61CAD19CF00886A1B /* String+validation.swift */,
+				2DE184071CB252C400E77F2F /* Reachability+isConnected.swift */,
+				2DE184091CB2739600E77F2F /* UITextField+isEmpty.swift */,
+				2DE1840D1CB27DD600E77F2F /* EmailValidatableTextField.swift */,
 			);
 			path = StudyBox_iOS;
 			sourceTree = "<group>";
@@ -488,6 +497,8 @@
 				7238493E1C8884DD009605EE /* TestViewController.swift in Sources */,
 				2D3A23911C99EEBD00CC90FF /* UIViewController+presentAlertController.swift in Sources */,
 				AEE35B8C1CA4747200D17A3C /* Results+toArray.swift in Sources */,
+				2DE184081CB252C400E77F2F /* Reachability+isConnected.swift in Sources */,
+				2DE1840A1CB2739600E77F2F /* UITextField+isEmpty.swift in Sources */,
 				2DD02DAB1C8CCE2B00A6FED9 /* UserViewController.swift in Sources */,
 				7238493A1C8882DE009605EE /* StudyBoxViewController.swift in Sources */,
 				2D70F7BF1C9FFBF1003DF156 /* SBReplaceSegue.swift in Sources */,
@@ -512,6 +523,7 @@
 				2D2843671C88CEEC006E5E21 /* DataModel.swift in Sources */,
 				AEE35B8E1CA4BCA800D17A3C /* DataModel+NSCopying.swift in Sources */,
 				2DFB7B231C88F7EE00164464 /* DataManager+DummyData.swift in Sources */,
+				2DE1840E1CB27DD700E77F2F /* EmailValidatableTextField.swift in Sources */,
 				7238493C1C88847F009605EE /* DecksViewController.swift in Sources */,
 				723849421C8885F7009605EE /* ScoreViewController.swift in Sources */,
 				72D1644A1CAFAC7D00AA32EE /* CircularLoaderView.swift in Sources */,

--- a/StudyBox_iOS/Base.lproj/Main.storyboard
+++ b/StudyBox_iOS/Base.lproj/Main.storyboard
@@ -19,7 +19,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-MAIL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7fq-pj-29a" customClass="ValidatableTextField" customModule="StudyBox_iOS" customModuleProvider="target">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-MAIL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7fq-pj-29a" customClass="EmailValidatableTextField" customModule="StudyBox_iOS" customModuleProvider="target">
                                 <rect key="frame" x="215" y="275" width="170" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="HNj-Fi-wBX"/>
@@ -384,7 +384,7 @@
                                     </constraint>
                                 </constraints>
                             </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-MAIL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5dY-gB-BHf">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="E-MAIL" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5dY-gB-BHf" customClass="EmailValidatableTextField" customModule="StudyBox_iOS" customModuleProvider="target">
                                 <rect key="frame" x="215" y="275" width="170" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="kYX-It-wtx"/>
@@ -393,7 +393,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
                             </textField>
-                            <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="POWTÓRZ HASŁO" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vTh-fE-OH6">
+                            <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="POWTÓRZ HASŁO" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="vTh-fE-OH6" customClass="ValidatableTextField" customModule="StudyBox_iOS" customModuleProvider="target">
                                 <rect key="frame" x="215" y="359" width="170" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="png-us-oFN"/>
@@ -428,7 +428,7 @@
                                     <action selector="register:" destination="MeD-mH-qFY" eventType="touchUpInside" id="3Bd-c6-IHw"/>
                                 </connections>
                             </button>
-                            <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HASŁO" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MsS-od-E0r">
+                            <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="HASŁO" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MsS-od-E0r" customClass="ValidatableTextField" customModule="StudyBox_iOS" customModuleProvider="target">
                                 <rect key="frame" x="215" y="317" width="170" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="170" id="pAJ-gq-Vha"/>

--- a/StudyBox_iOS/EmailValidatableTextField.swift
+++ b/StudyBox_iOS/EmailValidatableTextField.swift
@@ -1,0 +1,21 @@
+//
+//  EmailValidatableTextField.swift
+//  StudyBox_iOS
+//
+//  Created by Damian Malarczyk on 04.04.2016.
+//  Copyright © 2016 BLStream. All rights reserved.
+//
+
+import UIKit
+
+class EmailValidatableTextField: ValidatableTextField {
+
+    func isValid()-> Bool {
+        text = text?.trimWhiteCharacters()
+        if let textToValidate = text {
+            return textToValidate.isValidEmail()
+        }
+        return false
+    }
+
+}

--- a/StudyBox_iOS/LoginViewController.swift
+++ b/StudyBox_iOS/LoginViewController.swift
@@ -49,10 +49,11 @@ class LoginViewController: UserViewController,InputViewControllerDataSource {
             alertMessage = "Brak połączenia z Internetem"
         }
         
-        inputViews.reverse().forEach {
-            if let validatableTextField = $0 as? ValidatableTextField {
+        for inputView in inputViews {
+            if let validatableTextField = inputView as? ValidatableTextField {
                 if let message = validatableTextField.invalidMessage {
                     alertMessage = message
+                    break
                 }
             }
         }
@@ -77,7 +78,9 @@ class LoginViewController: UserViewController,InputViewControllerDataSource {
         var validationResult = true
         
         var invalidMessage:String?
-        textField.text = (textField.text as NSString?)?.stringByReplacingCharactersInRange(range, withString: string)
+        if let text = textField.text as NSString? {
+            textField.text = text.stringByReplacingCharactersInRange(range, withString: string)
+        }
         
         if textField == emailTextField, let _ = textField.text  {
             validationResult = emailTextField.isValid()

--- a/StudyBox_iOS/Reachability+isConnected.swift
+++ b/StudyBox_iOS/Reachability+isConnected.swift
@@ -1,0 +1,23 @@
+//
+//  Reachability+isConnected.swift
+//  StudyBox_iOS
+//
+//  Created by Damian Malarczyk on 04.04.2016.
+//  Copyright © 2016 BLStream. All rights reserved.
+//
+
+import Foundation
+import Reachability
+
+extension Reachability {
+    class func isConnected() -> Bool {
+        //returns true if connected, false if disconnected
+        let reachability = Reachability.reachabilityForInternetConnection()
+        
+        if reachability.currentReachabilityStatus() == .NotReachable {
+            return false
+        } else {
+            return true
+        }
+    }
+}

--- a/StudyBox_iOS/RegistrationViewController.swift
+++ b/StudyBox_iOS/RegistrationViewController.swift
@@ -14,9 +14,9 @@ var userDataForRegistration = [String : String]()
 
 class RegistrationViewController: UserViewController, InputViewControllerDataSource {
     
-    @IBOutlet weak var emailTextField: UITextField!
-    @IBOutlet weak var passwordTextField: UITextField!
-    @IBOutlet weak var repeatPasswordTextField: UITextField!
+    @IBOutlet weak var emailTextField: EmailValidatableTextField!
+    @IBOutlet weak var passwordTextField: ValidatableTextField!
+    @IBOutlet weak var repeatPasswordTextField: ValidatableTextField!
     @IBOutlet weak var registerButton: UIButton!
     @IBOutlet weak var cancelButton: UIButton!
     
@@ -30,103 +30,117 @@ class RegistrationViewController: UserViewController, InputViewControllerDataSou
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        /* the login button is by default disabled,
+        /* the register button is by default disabled,
          user has to enter some data and it has to be verified
          */
-        
-        if !isConnectedToInternet() {
-            showAlert(.noInternet)
-        }
-        
-        disableRegisterButton()
+        disableButton(registerButton)
         registerButton.layer.cornerRadius = 10.0
         
         inputViews.append(emailTextField)
         inputViews.append(passwordTextField)
         inputViews.append(repeatPasswordTextField)
-        
+        inputViews.forEach {
+            if let validable = $0 as? ValidatableTextField {
+                validable.validColor = UIColor.sb_DarkBlue()
+                validable.invalidColor = UIColor.sb_Raspberry()
+                validable.textColor = validable.validColor
+            }
+        }
         emailTextField.font = UIFont.sbFont(size: sbFontSizeMedium, bold: false)
         passwordTextField.font = UIFont.sbFont(size: sbFontSizeMedium, bold: false)
         repeatPasswordTextField.font = UIFont.sbFont(size: sbFontSizeMedium, bold: false)
         registerButton.titleLabel?.font = UIFont.sbFont(size: sbFontSizeMedium, bold: false)
     }
     
-    func isConnectedToInternet() -> Bool {
-        //returns true if connected, false if disconnected
-        let reachability = Reachability.reachabilityForInternetConnection()
-        
-        if reachability.currentReachabilityStatus() == .NotReachable {
-            return false
-        } else {
-            return true
-        }
-    }
     
-    func checkEmail(textField: UITextField) -> () {
-        if let text = textField.text where textField == emailTextField {
-            
-            textField.text = text.trimWhiteCharacters()
-            
-            if let text = textField.text {
-                if !text.isValidEmail() {
-                    showAlert(.emailIncorrect)
-
+    func registerWithInputData() {
+        var alertMessage:String?
+        
+        if !Reachability.isConnected() {
+            alertMessage = ValidationMessage.noInternet.rawValue
+        }
+        
+        inputViews.reverse().forEach {
+            if let validatableTextField = $0 as? ValidatableTextField {
+                if let message = validatableTextField.invalidMessage {
+                    alertMessage = message
                 }
             }
         }
-    }
-    
-    func checkPasswordLengthAndSpaces(password: UITextField) {
-        if let characterCount = password.text?.characters.count {
-            if characterCount < 8 && characterCount != 0 {
-                showAlert(.passwordTooShort)
-                //To prevent popping up multiple error alerts
-                repeatPasswordTextField.resignFirstResponder()
-            }
-        }
-        if (password.text?.containsString(" ") == true) {
-            showAlert(.passwordContainsSpace)
-            repeatPasswordTextField.resignFirstResponder()
-        }
-    }
-    
-    func checkPasswordsMatch(password1 password1:UITextField, password2:UITextField) {
         
-        if (password1.text != "" && password2.text != "") {
-            if (password1.text != password2.text){
-                password1.textColor = UIColor.sb_Raspberry()
-                password2.textColor = UIColor.sb_Raspberry()
-                showAlert(.passwordsDontMatch)
-                disableRegisterButton()
-            }
-            else {
-                password1.textColor = UIColor.sb_DarkBlue()
-                password2.textColor = UIColor.sb_DarkBlue()
-                
-                enableRegisterButton()
-            }
+        if areTextFieldsEmpty() {
+            alertMessage = ValidationMessage.fieldsAreEmpty.rawValue
+        }
+        
+        if let message = alertMessage {
+            presentAlertController(withTitle: "", message: message, buttonText: "Ok")
         } else {
-            disableRegisterButton()
+            dismissViewControllerAnimated(true) {[unowned self] in
+                self.successfulLoginTransition()
+            }
         }
     }
     
-    func textFieldDidEndEditing(editedTextField: UITextField) {
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        var validationResult = true
         
-        switch editedTextField {
+        
+        textField.text = (textField.text as NSString?)?.stringByReplacingCharactersInRange(range, withString: string)
+        var invalidMessage:String? = nil 
+        if textField == emailTextField, let _ = textField.text {
+            validationResult = emailTextField.isValid()
+            if !validationResult {
+                invalidMessage = ValidationMessage.emailIncorrect.rawValue
+            }
             
-        case emailTextField:
-            checkEmail(editedTextField)
-            checkPasswordsMatch(password1: passwordTextField, password2: repeatPasswordTextField)
+        } else if let text = textField.text {
+            validationResult = text.hasMinimumCharacters(minimum: Utils.UserAccount.MinimumPasswordLength)
             
-        case passwordTextField:
-            checkPasswordLengthAndSpaces(passwordTextField)
+            if !validationResult {
+                invalidMessage = ValidationMessage.passwordTooShort.rawValue
+            } else {
+                validationResult = !text.hasWhitespaceOrNewLineCharacter()
+                
+                if !validationResult {
+                    invalidMessage = ValidationMessage.passwordIncorrect.rawValue
+                } else {
+                    var matchingField:UITextField?
+                    
+                    if textField == passwordTextField {
+                        matchingField = repeatPasswordTextField
+                    } else {
+                        matchingField = passwordTextField
+                    }
+                    
+                    if let validatableMatchingField = matchingField as? ValidatableTextField where validatableMatchingField.text != "" {
+                        validationResult = text == validatableMatchingField.text
+                        if !validationResult {
+                            invalidMessage = ValidationMessage.passwordsDontMatch.rawValue
+                            validatableMatchingField.invalidMessage = invalidMessage
+                        }else {
+                            validatableMatchingField.invalidMessage = nil
+                        }
+                        
+                    }
+                    
+                }
+            }
             
-        case repeatPasswordTextField:
-            checkPasswordsMatch(password1: passwordTextField, password2: repeatPasswordTextField)
             
-        default:
-            return
         }
+        
+        if let validatableTextField = textField as? ValidatableTextField {
+            validatableTextField.invalidMessage = invalidMessage
+        }
+        
+        if areTextFieldsValid() {
+            enableButton(registerButton)
+        } else {
+            disableButton(registerButton)
+        }
+        
+        return false
+        
     }
     
     func textFieldShouldReturn(textField: UITextField) -> Bool {
@@ -139,9 +153,7 @@ class RegistrationViewController: UserViewController, InputViewControllerDataSou
         if (nextResponder != nil) {
             // Found next responder, so set it.
             nextResponder?.becomeFirstResponder()
-        }
-        else
-        {
+        } else {
             // Not found, so hide keyboard
             textField.resignFirstResponder()
         }
@@ -153,63 +165,6 @@ class RegistrationViewController: UserViewController, InputViewControllerDataSou
     }
     
     @IBAction func register(sender: UIButton) {
-        
-        let areTextFieldsNotEmpty = emailTextField.text != "" && passwordTextField.text != "" && repeatPasswordTextField.text != ""
-        
-        if (areTextFieldsNotEmpty && isConnectedToInternet()) {
-            userDataForRegistration["email"] = emailTextField.text
-            userDataForRegistration["password"] = repeatPasswordTextField.text
-            
-            //TODO: pass over the dictionary with data
-            dismissViewControllerAnimated(true) {[unowned self] () -> Void in
-                self.successfulLoginTransition() }
-        }
-        else if !areTextFieldsNotEmpty {
-            showAlert(.fieldsNotEmpty)
-        } else if !isConnectedToInternet() {
-            showAlert(.noInternet)
-        }
+        registerWithInputData()
     }
-    
-    func disableRegisterButton() {
-        registerButton.backgroundColor = UIColor.grayColor()
-        registerButton.enabled = false
-    }
-    
-    func enableRegisterButton() {
-        registerButton.backgroundColor = UIColor.sb_Raspberry()
-        registerButton.enabled = true
-    }
-    
-    enum alertType {
-        case passwordTooShort
-        case passwordsDontMatch
-        case emailIsTaken
-        case passwordContainsSpace
-        case noInternet
-        case emailIncorrect
-        case fieldsNotEmpty
-    }
-    
-    let alertMessagesDict:[alertType : (String,String)] = [
-        .noInternet : ("Brak połączenia","Nie można połączyć się z Internetem. Sprawdź połączenie"),
-        .emailIsTaken : ("Adres e-mail zajęty", "Już istnieje konto z takim adresem e-mail."),
-        .passwordContainsSpace : ("Spacja w haśle", "Hasło nie może zawierać spacji."),
-        .emailIncorrect : ("Niepoprawny adres e-mail", "Adres e-mail zawiera spację lub jest w złym formacie."),
-        .passwordsDontMatch : ("Hasła są różne","Oba hasła muszą być identyczne."),
-        .passwordTooShort : ("Za krótkie hasło", "Hasło musi mieć co najmniej 8 znaków."),
-        .fieldsNotEmpty : ("Wypełnij pola","Sprawdź czy wszystkie pola formularza są wypełnione.")
-    ]
-    
-    func showAlert(type: alertType) {
-        
-        let alertController = UIAlertController(title: alertMessagesDict[type]!.0,
-                                                message: alertMessagesDict[type]!.1,
-                                                preferredStyle: .Alert)
-        
-        let actionOk = UIAlertAction(title: "OK", style: .Default, handler: nil)
-        alertController.addAction(actionOk)
-        self.presentViewController(alertController, animated: true, completion: nil)
-    }
-    
 }

--- a/StudyBox_iOS/RegistrationViewController.swift
+++ b/StudyBox_iOS/RegistrationViewController.swift
@@ -60,10 +60,11 @@ class RegistrationViewController: UserViewController, InputViewControllerDataSou
             alertMessage = ValidationMessage.noInternet.rawValue
         }
         
-        inputViews.reverse().forEach {
-            if let validatableTextField = $0 as? ValidatableTextField {
+        for inputView in inputViews {
+            if let validatableTextField = inputView as? ValidatableTextField {
                 if let message = validatableTextField.invalidMessage {
                     alertMessage = message
+                    break
                 }
             }
         }
@@ -85,7 +86,10 @@ class RegistrationViewController: UserViewController, InputViewControllerDataSou
         var validationResult = true
         
         
-        textField.text = (textField.text as NSString?)?.stringByReplacingCharactersInRange(range, withString: string)
+        if let text = textField.text as NSString? {
+            textField.text = text.stringByReplacingCharactersInRange(range, withString: string)
+        }
+        
         var invalidMessage:String? = nil 
         if textField == emailTextField, let _ = textField.text {
             validationResult = emailTextField.isValid()

--- a/StudyBox_iOS/String+validation.swift
+++ b/StudyBox_iOS/String+validation.swift
@@ -19,7 +19,15 @@ extension String {
         return !containsString(" ") && containsString("@")
     }
     
-    func isValidPassword() -> Bool {
-        return characters.count > 7 && rangeOfCharacterFromSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) == nil
+    func isValidPassword(minimumCharacters x:Int) -> Bool {
+        return hasMinimumCharacters(minimum: x) && !hasWhitespaceOrNewLineCharacter()
+    }
+    
+    func hasMinimumCharacters(minimum x:Int)->Bool {
+        return characters.count >= x
+    }
+    
+    func hasWhitespaceOrNewLineCharacter()->Bool {
+        return rangeOfCharacterFromSet(NSCharacterSet.whitespaceAndNewlineCharacterSet()) != nil
     }
 }

--- a/StudyBox_iOS/UITextField+isEmpty.swift
+++ b/StudyBox_iOS/UITextField+isEmpty.swift
@@ -1,0 +1,21 @@
+//
+//  UITextField+isEmpty.swift
+//  StudyBox_iOS
+//
+//  Created by Damian Malarczyk on 04.04.2016.
+//  Copyright © 2016 BLStream. All rights reserved.
+//
+
+import UIKit
+
+extension UITextField {
+    func isEmpty()-> Bool  {
+        if let text = text {
+            if text.isEmpty {
+                return true
+            }
+            return false
+        }
+        return true
+    }
+}

--- a/StudyBox_iOS/UIViewController+presentAlertController.swift
+++ b/StudyBox_iOS/UIViewController+presentAlertController.swift
@@ -16,7 +16,7 @@ extension UIViewController {
         alert.addAction( UIAlertAction(title: buttonText, style: .Default) { (_) in
             actionCompletion?()
             
-            self.dismissViewControllerAnimated(true) {
+            alert.dismissViewControllerAnimated(true) {
                 dismissCompletion?()
             }
         })

--- a/StudyBox_iOS/UserViewController.swift
+++ b/StudyBox_iOS/UserViewController.swift
@@ -45,24 +45,23 @@ class UserViewController: InputViewController {
         
     }
     
-    func validateTextFieldsNotEmpty()->Bool {
+    func areTextFieldsEmpty()->Bool {
         
         if let inputViews = dataSource?.inputViews {
             for field in inputViews {
-                guard let text = field.text where text.characters.count > 0 else {
-                    return false
+                if field.isEmpty() {
+                    return true
                 }
             }
         }
-
-        return true
+        return false 
     }
     
     func areTextFieldsValid()-> Bool {
         if let inputViews = dataSource?.inputViews {
             for field in inputViews {
-                if let validableField = field as? ValidatableTextField {
-                    if !validableField.isValid {
+                if let validatableField = field as? ValidatableTextField {
+                    if validatableField.isEmpty() || validatableField.invalidMessage != nil {
                         return false 
                     }
                 }
@@ -70,6 +69,24 @@ class UserViewController: InputViewController {
         }
         
         return true
+    }
+    
+    func disableButton(button:UIButton) {
+        button.backgroundColor = UIColor.sb_DarkGrey()
+    }
+    
+    func enableButton(button:UIButton) {
+        button.backgroundColor = UIColor.sb_Raspberry()
+    }
+    
+    enum ValidationMessage:String  {
+        case passwordTooShort = "Hasła są zbyt krótkie"
+        case passwordsDontMatch = "Hasła nie są jednakowe!"
+        case passwordContainsSpace = "Nie można użyć w haśle białych znaków!"
+        case passwordIncorrect = "Niepoprawne hasło"
+        case noInternet = "Brak połączenia z Internetem"
+        case emailIncorrect = "Niepoprawny e-mail!"
+        case fieldsAreEmpty = "Wypełnij wszystkie pola!"
     }
     
 }

--- a/StudyBox_iOS/Utils.swift
+++ b/StudyBox_iOS/Utils.swift
@@ -22,4 +22,8 @@ class Utils {
         static let DecksInRowIPhoneVer: CGFloat = 2
         static let DeckWithoutTitle = "Bez tytułu"
     }
+    
+    struct UserAccount {
+        static let MinimumPasswordLength = 8
+    }
 }

--- a/StudyBox_iOS/ValidatableTextField.swift
+++ b/StudyBox_iOS/ValidatableTextField.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 class ValidatableTextField: UITextField {
-
-    var isValid:Bool = false {
+    
+    var invalidMessage:String? {
         didSet {
-            if isValid {
+            if invalidMessage == nil {
                 textColor = validColor
-            }else {
+            } else {
                 textColor = invalidColor
             }
         }
@@ -22,3 +22,4 @@ class ValidatableTextField: UITextField {
     var validColor:UIColor!
     var invalidColor:UIColor!
 }
+


### PR DESCRIPTION
- adapt `ValidatableTextField` to handle one field having different validation messages
- apply `ValidatableTextField` pattern to `RegistrationViewController` - validation in place with input colors, validation messages only on action button touch
- abstract part of validation logic for `UserViewController`
- unify Login and Registration validation logic
- adjust `UIViewController+presentAlertController` extension