### PR TITLE
fix/SB-566 - Fix empty cells in settings, clear user data on logout

### DIFF
--- a/StudyBox_iOS/DataManager.swift
+++ b/StudyBox_iOS/DataManager.swift
@@ -132,8 +132,6 @@ public class DataManager {
 
     func logout() {
         remoteDataManager.logout()
-        let decks = localDataManager.getAll(Deck.self)
-        localDataManager.delete(decks)
         clearUserDefaults()
     }
 

--- a/StudyBox_iOS/DataManager.swift
+++ b/StudyBox_iOS/DataManager.swift
@@ -132,11 +132,20 @@ public class DataManager {
 
     func logout() {
         remoteDataManager.logout()
+        let decks = localDataManager.getAll(Deck.self)
+        localDataManager.delete(decks)
+        clearUserDefaults()
     }
 
+    func clearUserDefaults() {
+        let defaults = NSUserDefaults.standardUserDefaults()
+        defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.DecksToSynchronizeKey)
+        defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.NotificationsEnabledKey)
+        defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.PickerFrequencyNumberKey)
+        defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.PickerFrequencyTypeKey)
+    }
+    
     //MARK: Decks
-    
-    
     func deck(withId deckID: String, completion: (DataManagerResponse<Deck>)-> ()) {
         handleJSONRequest(
             localFetch: {

--- a/StudyBox_iOS/SettingsDetailViewController.swift
+++ b/StudyBox_iOS/SettingsDetailViewController.swift
@@ -35,7 +35,6 @@ class SettingsDetailViewController: StudyBoxViewController, UITableViewDataSourc
         switch mode {
         case .DecksForWatch?:
             self.title = "Wybór talii"
-            
             userDecksArray = dataManager.localDataManager.getAll(Deck)
         case .Frequency?:
             self.title = "Powiadomienia"
@@ -164,29 +163,34 @@ class SettingsDetailViewController: StudyBoxViewController, UITableViewDataSourc
             return
         }
         
-        if let decksToSynchronize = defaults.objectForKey(Utils.NSUserDefaultsKeys.DecksToSynchronizeKey) as? [String]{
-            switch indexPath.section {
-            case 0:
-                //Check the "Select/deselect all" cell if all decks are already set to sync
-                if decksToSynchronize.count == userDecksArray.count {
+        let decksToSynchronize: [String]
+        if let decksToSync = defaults.objectForKey(Utils.NSUserDefaultsKeys.DecksToSynchronizeKey) as? [String] {
+            decksToSynchronize = decksToSync
+        } else {
+            decksToSynchronize = []
+        }
+        
+        switch indexPath.section {
+        case 0:
+            //Check the "Select/deselect all" cell if all decks are already set to sync
+            if decksToSynchronize.count == userDecksArray.count {
+                cell.accessoryType = .Checkmark
+            }
+            
+            cell.textLabel?.text = "Zaznacz/Odznacz wszystkie"
+        case 1:
+            let deckName = userDecksArray[indexPath.row].name
+            cell.textLabel?.text = deckName.isEmpty ? Utils.DeckViewLayout.DeckWithoutTitle : deckName
+            cell.accessoryType = .None
+            
+            //Enable the checkmark if `decksToSynchronize` contains current Deck in cell
+            for deckToSync in decksToSynchronize where !decksToSynchronize.isEmpty {
+                if deckToSync == userDecksArray[indexPath.row].serverID {
                     cell.accessoryType = .Checkmark
                 }
-                
-                cell.textLabel?.text = "Zaznacz/Odznacz wszystkie"
-            case 1:
-                let deckName = userDecksArray[indexPath.row].name
-                cell.textLabel?.text = deckName.isEmpty ? Utils.DeckViewLayout.DeckWithoutTitle : deckName
-                
-                cell.accessoryType = .None
-                //Enable the checkmark if `decksToSynchronize` contains current Deck in cell
-                for deckToSync in decksToSynchronize {
-                    if deckToSync == userDecksArray[indexPath.row].serverID {
-                        cell.accessoryType = .Checkmark
-                    }
-                }
-                
-            default: break
             }
+            
+        default: break
         }
     }
 


### PR DESCRIPTION
- Poprawione wyświetlanie pustej listy talii przy pierwszym uruchomieniu
- Przy wylogowywaniu dane w `NSUserDefaults` i lokalne talie są czyszczone bo pojawiały się w ustawieniach po wylogowaniu i wejściu jako niezalogowany.