### PR TITLE
Delete all data on logout

### DIFF
--- a/StudyBox_iOS/DataManager.swift
+++ b/StudyBox_iOS/DataManager.swift
@@ -133,6 +133,7 @@ public class DataManager {
     func logout() {
         remoteDataManager.logout()
         clearUserDefaults()
+        clearLocalDataManager()
     }
 
     func clearUserDefaults() {
@@ -141,6 +142,12 @@ public class DataManager {
         defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.NotificationsEnabledKey)
         defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.PickerFrequencyNumberKey)
         defaults.removeObjectForKey(Utils.NSUserDefaultsKeys.PickerFrequencyTypeKey)
+    }
+    
+    func clearLocalDataManager() {
+        localDataManager.deleteAll(Deck.self)
+        localDataManager.deleteAll(Flashcard.self)
+        localDataManager.deleteAll(Tip.self)
     }
     
     //MARK: Decks


### PR DESCRIPTION
Usuwanie wszystkich danych lokalnych z DataManagera przy wylogowywaniu co zapobiega pokazywaniu talii starego użytkownika w ustawieniach.