### PR TITLE
Fix statistics

### DIFF
--- a/StudyBox_iOS/Base.lproj/Main.storyboard
+++ b/StudyBox_iOS/Base.lproj/Main.storyboard
@@ -599,7 +599,7 @@
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="EBI-XT-SoF">
                                 <rect key="frame" x="216" y="150" width="168" height="301"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Poprawne odpowiedzi" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dpk-pf-DVj">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Poprawne odpowiedzi" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dpk-pf-DVj">
                                         <rect key="frame" x="0.0" y="0.0" width="168" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/StudyBox_iOS/DataManager.swift
+++ b/StudyBox_iOS/DataManager.swift
@@ -164,9 +164,10 @@ public class DataManager {
     }
     
     func clearLocalDataManager() {
-        localDataManager.deleteAll(Deck.self)
-        localDataManager.deleteAll(Flashcard.self)
-        localDataManager.deleteAll(Tip.self)
+        localDataManager.deleteAll(Deck)
+        localDataManager.deleteAll(Flashcard)
+        localDataManager.deleteAll(Tip)
+        localDataManager.deleteAll(TestInfo)
     }
     
     //MARK: Decks

--- a/StudyBox_iOS/StatisticsViewController.swift
+++ b/StudyBox_iOS/StatisticsViewController.swift
@@ -24,8 +24,13 @@ class StatisticsViewController: StudyBoxViewController {
         circularProgressView.progress = 0
         clearButton.backgroundColor = UIColor.sb_Raspberry()
         clearButton.setTitleColor(UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1), forState: UIControlState.Normal)
-        clearButton.titleLabel?.font = UIFont.sbFont(size: sbFontSizeMedium, bold: false)
+        clearButton.titleLabel?.font = UIFont.sbFont(bold: false)
         clearButton.layer.cornerRadius = 10
+        
+        infoLabel.font = UIFont.sbFont(bold: false)
+        decksAmount.font = UIFont.sbFont(bold: false)
+        testsAmount.font = UIFont.sbFont(bold: false)
+        flashcardsScore.font = UIFont.sbFont(size: sbFontSizeLarge, bold: true)
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -41,13 +46,13 @@ class StatisticsViewController: StudyBoxViewController {
             flashcardsScore.text = nil
             decksAmount.text = nil
             testsAmount.text = nil
-            infoLabel.text = "Zbyt mało danych"
+            infoLabel.text = "Nie przeprowadzono \njeszcze żadnego testu."
             circularProgressView.animateProgress(0)
             clearButton.hidden = true
             return
         }
         clearButton.hidden = false
-        infoLabel.text = "Poprawne odpowiedzi"
+        infoLabel.text = "Poprawne odpowiedzi:"
         let allFlashcards = tests.reduce(0) {
             return $0.0 + $0.1.answeredFlashcardsCount
         }
@@ -57,7 +62,7 @@ class StatisticsViewController: StudyBoxViewController {
         flashcardsScore.text = "\(correctlyAnsweredFlashcards)/\(allFlashcards)"
         
         let decks = tests.map { $0.deck }.unqiueElements()
-        decksAmount.text = "Ilość talii: \(decks.count)"
+        decksAmount.text = "Ilość testowanych talii: \(decks.count)"
         testsAmount.text = "Ilość testów: \(tests.count)"
         circularProgressView.animateProgress(CGFloat(correctlyAnsweredFlashcards) / CGFloat(allFlashcards))
     }


### PR DESCRIPTION
- Usuwanie obiektów `TestLogic` przy wylogowywaniu: po zalogowaniu innego użytkownika w bazie istniały obiekty `TestLogic` ale pole `.deck` było nullem, co powodowało błąd przy rozpakowywaniu w `.map`
- Poprawki interfejsu ekranu statystyk